### PR TITLE
Rebuild against qtbase with libjpeg-turbo

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+libvulkan:
+  - 1.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - patches/0002-Fix-internal-target-exports-in-Wayland-modules.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
   detect_binary_files_with_prefix: true
   # https://doc.qt.io/qt-6/qt-releases.html#binary-compatibility


### PR DESCRIPTION
qtwayland 6.11.0
**Destination channel:** defaults

### Links

- [PKG-15537](https://anaconda.atlassian.net/browse/PKG-15537) 
- [Upstream repository](https://github.com/qt/qtwayland/tree/v6.11.0)

### Explanation of changes:
- Rebuild against qtbase with libjpeg-turbo


[PKG-15537]: https://anaconda.atlassian.net/browse/PKG-15537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ